### PR TITLE
Bugfix and two new settings to toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ If you have cutecord style notifications enabled, this is how we handle them.
 
 ---
 ## Changelog
+
+### v3.3.1
+Clearified what "Lurking guilds" Actually means, (No, it doesn't mean muted guilds!)
+Added option to still get notified by cuties even if they said something in a muted guild
+Added option to still get notified by cuties even if you can already see them (In the current chat)
+Fixed case insensitive not working with capatalized cute words
 ### v3.3.0
 Added ability to toggle between case sensitive and insensitive keyword
 detection. The default has been set to case insensitive detection.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ If you have cutecord style notifications enabled, this is how we handle them.
 ## Changelog
 
 ### v3.3.1
-Clearified what "Lurking guilds" Actually means, (No, it doesn't mean muted guilds!)
-Added option to still get notified by cuties even if they said something in a muted guild
-Added option to still get notified by cuties even if you can already see them (In the current chat)
-Fixed case insensitive not working with capatalized cute words
+Additions:
+- Override the mute state of a channel
+- Display notifications even if message originated in current channel
+
+Changes:
+- Changed "Lurking Guilds" to "Preview Guilds"
+
+Fixes: 
+- Case insensitive not working when keywords where capatalized
 ### v3.3.0
 Added ability to toggle between case sensitive and insensitive keyword
 detection. The default has been set to case insensitive detection.

--- a/Settings.jsx
+++ b/Settings.jsx
@@ -16,6 +16,8 @@ module.exports = class Settings extends React.Component {
       highlightKeywords: this.props.getSetting('highlightKeywords', true),
       lurkedGuilds: this.props.getSetting('lurkedGuilds', false),
       managedChannels: this.props.getSetting('managedChannels', false),
+      overwriteChatFocus: this.props.getSetting('overwriteChatFocus', false),
+      overwriteMuteSupression: this.props.getSetting('overwriteMuteSupression', false),
 
       blockEveryone: this.props.getSetting('blockEveryone', false),
       blockRoles: this.props.getSetting('blockRoles', false),
@@ -227,7 +229,7 @@ module.exports = class Settings extends React.Component {
           Highlight Cute Words
         </SwitchItem>
         <SwitchItem
-          note="Do you want to get notifications in guilds you're lurking?"
+          note="Do you want to get notifications in guilds you are lurking in? (Lurked servers are ones where you can't chat)"
           style={{ marginTop: '16px' }}
           value={this.state.lurkedGuilds}
           onChange={() => {
@@ -236,6 +238,28 @@ module.exports = class Settings extends React.Component {
           }}
         >
           Lurked Guilds
+        </SwitchItem>
+        <SwitchItem
+          note="Do you want to get notifications in guilds you have muted?"
+          style={{ marginTop: '16px' }}
+          value={this.state.overwriteMuteSupression}
+          onChange={() => {
+            this.setState({ overwriteMuteSupression: !this.state.overwriteMuteSupression });
+            this.props.toggleSetting('overwriteMuteSupression');
+          }}
+        >
+          Muted Guilds
+        </SwitchItem>
+        <SwitchItem
+          note="Notify even if cute message is sent in currently focused chat"
+          style={{ marginTop: '16px' }}
+          value={this.state.overwriteChatFocus}
+          onChange={() => {
+            this.setState({ overwriteChatFocus: !this.state.overwriteChatFocus });
+            this.props.toggleSetting('overwriteChatFocus');
+          }}
+        >
+          Always Show Cute
         </SwitchItem>
         <SwitchItem
           note="I have no idea what a managed channel is"
@@ -250,7 +274,7 @@ module.exports = class Settings extends React.Component {
         </SwitchItem>
       </Category>
 
-      <div style={{ marginTop: '10rem'}}>
+      <div style={{ marginTop: '10rem' }}>
         <img
           src='https://canary.discordapp.com/assets/62dc78f6f9a73954e6454da485ea8147.svg'
           alt='emma cute'

--- a/Settings.jsx
+++ b/Settings.jsx
@@ -17,7 +17,7 @@ module.exports = class Settings extends React.Component {
       lurkedGuilds: this.props.getSetting('lurkedGuilds', false),
       managedChannels: this.props.getSetting('managedChannels', false),
       overwriteChatFocus: this.props.getSetting('overwriteChatFocus', false),
-      overwriteMuteSupression: this.props.getSetting('overwriteMuteSupression', false),
+      overwriteMute: this.props.getSetting('overwriteMute', false),
 
       blockEveryone: this.props.getSetting('blockEveryone', false),
       blockRoles: this.props.getSetting('blockRoles', false),
@@ -229,7 +229,7 @@ module.exports = class Settings extends React.Component {
           Highlight Cute Words
         </SwitchItem>
         <SwitchItem
-          note="Do you want to get notifications in guilds you are lurking in? (Lurked servers are ones where you can't chat)"
+          note="Do you want to get notifications in guilds you are previewing"
           style={{ marginTop: '16px' }}
           value={this.state.lurkedGuilds}
           onChange={() => {
@@ -242,10 +242,10 @@ module.exports = class Settings extends React.Component {
         <SwitchItem
           note="Do you want to get notifications in guilds you have muted?"
           style={{ marginTop: '16px' }}
-          value={this.state.overwriteMuteSupression}
+          value={this.state.overwriteMute}
           onChange={() => {
-            this.setState({ overwriteMuteSupression: !this.state.overwriteMuteSupression });
-            this.props.toggleSetting('overwriteMuteSupression');
+            this.setState({ overwriteMute: !this.state.overwriteMute });
+            this.props.toggleSetting('overwriteMute');
           }}
         >
           Muted Guilds

--- a/Settings.jsx
+++ b/Settings.jsx
@@ -237,7 +237,7 @@ module.exports = class Settings extends React.Component {
             this.props.toggleSetting('lurkedGuilds');
           }}
         >
-          Lurked Guilds
+          Preview Guilds
         </SwitchItem>
         <SwitchItem
           note="Do you want to get notifications in guilds you have muted?"

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = class Cutecord extends Plugin {
       'type',
       (args) => {
         const [ { message } ] = args
-        if (!message.originalMentioned) {
+        if (message.originalMentioned === undefined) {
           message.originalMentioned = message.mentioned
         }
         if (this.settings.get('highlightKeywords', true)) {
@@ -216,10 +216,10 @@ module.exports = class Cutecord extends Plugin {
       return false
     }
 
-    const overwriteMuteSupression = this.settings.get('overwriteMuteSupression')
-    if (notificationSettings.allowNoMessages(channel) && !overwriteMuteSupression) {
-      // No. Unless we want them... I really do, don't judge me.
-      return false
+    let muteMessage = false
+    if (notificationSettings.allowNoMessages(channel)) {
+      // if channel is muted, check if user wants to overwrite it when cute is detected
+      muteMessage = !this.settings.get('overwriteMute')
     }
 
     let status = getStatus()
@@ -243,16 +243,26 @@ module.exports = class Cutecord extends Plugin {
 
     // Here's the magic part :zoomeyes:
     if (this.settings.get('cuteUsers', []).includes(msgAuthor.id)) {
+      if (muteMessage) {
+        return false
+      }
       return true
     }
 
     if (this.settings.get('cuteChannels', []).includes(channel.id)) {
+      if (muteMessage) {
+        return false
+      }
       return true
     }
 
     if (this.settings.get('cuteGuilds', []).includes(guildID)) {
+      if (muteMessage) {
+        return false
+      }
       return true
     }
+
 
     if (override === 'cute') {
       return status !== StatusTypes.DND

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Cutecord",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Make discord cuter.",
   "author": "katlyn",
   "license": "MIT"


### PR DESCRIPTION
- Fixed case insensitive not working with capitalized cute words, can't modify an object while iterating over it.
- Implemented setting to toggle cutecord for lurking guilds, the setting was never used from what I saw
- Added setting to get notified by cute words even if it originated from a muted guild
- Added setting to get notified even if you are focused on the channel the message originated from
- Clarified what "Lurking guilds" mean as before I've seen it refereed to as guilds you have muted.