### PR TITLE
Fix Menu patch stripping the displayName, breaking other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,7 @@ module.exports = class Cutecord extends Plugin {
       },
       true
     )
+    Menu.default.displayName = 'Menu'
 
     const GuildContextMenu = getModule((m) => m.default && m.default.displayName === 'GuildContextMenu', false)
     inject(


### PR DESCRIPTION
Powercord does not readd all properties of the original function after patching, this can break a lot of things, especially other plugins trying to find something by displayName, bd and pc plugins alike.